### PR TITLE
fix: preserve post-merge CI with user-owned auto-merge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,14 +150,19 @@ jobs:
             echo "Review Evidence requires the pull request to be Ready for review."
             exit 1
           fi
-      - name: Arm native squash auto-merge before final evidence
+      - name: Verify user-owned native squash auto-merge before final evidence
         env:
           GH_TOKEN: ${{ github.token }}
           REPOSITORY: ${{ github.repository }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
+          EXPECTED_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           set -euo pipefail
-          gh pr merge "$PR_NUMBER" --repo "$REPOSITORY" --auto --squash
+          python scripts/review_evidence.py \
+            --verify-auto-merge \
+            --repository "$REPOSITORY" \
+            --pr-number "$PR_NUMBER" \
+            --expected-head-sha "$EXPECTED_HEAD_SHA"
       - name: Generate Review Evidence manifest
         env:
           GH_TOKEN: ${{ github.token }}

--- a/backend/tests/test_review_evidence.py
+++ b/backend/tests/test_review_evidence.py
@@ -11,6 +11,8 @@ from scripts.capture_service_logs import DEFAULT_COMMAND, capture_service_logs, 
 from scripts.review_bundle import deterministic_zip
 from scripts.review_evidence import (
     SCHEMA_PATH,
+    WO008_G1_ALLOWED_PATHS,
+    WO008_G1_BASE_SHA,
     auto_merge_evidence,
     canonical_change_evidence,
     canonical_change_statement,
@@ -20,6 +22,7 @@ from scripts.review_evidence import (
     parse_work_order_marker,
     require_hive_final_handoff,
     require_wo008_c1_evidence,
+    require_wo008_g1_scope,
     summary_markdown,
     validate_manifest,
     verify_native_auto_merge,
@@ -132,6 +135,7 @@ def evidence_fixture() -> dict[str, object]:
                 "delete_branch_on_merge": True,
                 "allow_auto_merge": False,
             },
+            "ruleset_unchanged": True,
             "pull_request": {
                 "number": 42,
                 "state": "open",
@@ -259,6 +263,7 @@ def handoff_governance(
     independent_approval_count: int = 0,
 ) -> dict[str, object]:
     return {
+        "ruleset_unchanged": True,
         "pull_request": {
             "state": "open",
             "is_draft": False,
@@ -297,6 +302,53 @@ def test_hive_final_handoff_requires_armed_squash_and_zero_approvals() -> None:
 def test_hive_final_handoff_rejects_manifest_pr_head_mismatch() -> None:
     with pytest.raises(ValueError, match="does not match PR head"):
         require_hive_final_handoff("WO-007-P", 28, "a" * 40, "c" * 40, handoff_governance())
+
+
+def test_g1_handoff_requires_exact_base_ruleset_and_user_owned_auto_merge() -> None:
+    governance = handoff_governance(base_sha=WO008_G1_BASE_SHA)
+    require_hive_final_handoff("WO-008-G1", 30, WO008_G1_BASE_SHA, "b" * 40, governance)
+
+    wrong_base = handoff_governance(base_sha="a" * 40)
+    with pytest.raises(ValueError, match="exact base"):
+        require_hive_final_handoff("WO-008-G1", 30, "a" * 40, "b" * 40, wrong_base)
+
+    bot_owned = handoff_governance(base_sha=WO008_G1_BASE_SHA)
+    bot_pull_request = cast(dict[str, object], bot_owned["pull_request"])
+    bot_auto_merge = cast(dict[str, object], bot_pull_request["auto_merge"])
+    bot_auto_merge["user_owned"] = False
+    with pytest.raises(ValueError, match="user-owned"):
+        require_hive_final_handoff("WO-008-G1", 30, WO008_G1_BASE_SHA, "b" * 40, bot_owned)
+
+    changed_ruleset = handoff_governance(base_sha=WO008_G1_BASE_SHA)
+    changed_ruleset["ruleset_unchanged"] = False
+    with pytest.raises(ValueError, match="ruleset"):
+        require_hive_final_handoff("WO-008-G1", 30, WO008_G1_BASE_SHA, "b" * 40, changed_ruleset)
+
+
+def test_g1_scope_rejects_non_governance_files() -> None:
+    require_wo008_g1_scope("WO-008-G1", WO008_G1_BASE_SHA, sorted(WO008_G1_ALLOWED_PATHS))
+    with pytest.raises(ValueError, match="outside"):
+        require_wo008_g1_scope(
+            "WO-008-G1",
+            WO008_G1_BASE_SHA,
+            [".github/workflows/ci.yml", "backend/app/reranking.py"],
+        )
+
+
+def test_g1_manifest_records_user_owned_identity_and_scope() -> None:
+    manifest = evidence_fixture()
+    manifest["work_order"] = "WO-008-G1"
+    manifest["base"] = {"branch": "main", "sha": WO008_G1_BASE_SHA}
+    manifest["changed_files"] = {
+        "count": 1,
+        "paths": ["scripts/review_evidence.py"],
+    }
+
+    validate_manifest(manifest)
+    review_state = cast(dict[str, object], manifest["review_state"])
+    assert review_state["auto_merge_owner_login"] == "KayzenRoot"
+    assert review_state["auto_merge_owner_type"] == "User"
+    assert review_state["auto_merge_user_owned"] is True
 
 
 def native_auto_merge_pull_request(auto_merge: object) -> dict[str, object]:
@@ -371,6 +423,26 @@ def test_native_auto_merge_verification_fails_closed(
     monkeypatch.setattr(review_evidence, "_gh_json", lambda _repository, _endpoint: pull_request)
 
     with pytest.raises(ValueError, match=message):
+        verify_native_auto_merge("KayzenRoot/hive", 42, "b" * 40)
+
+
+def test_native_auto_merge_verification_rejects_draft_and_moved_head(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    pull_request = native_auto_merge_pull_request(
+        {
+            "merge_method": "squash",
+            "enabled_by": {"login": "KayzenRoot", "type": "User"},
+        }
+    )
+    monkeypatch.setattr(review_evidence, "_gh_json", lambda _repository, _endpoint: pull_request)
+    pull_request["draft"] = True
+    with pytest.raises(ValueError, match="Ready"):
+        verify_native_auto_merge("KayzenRoot/hive", 42, "b" * 40)
+
+    pull_request["draft"] = False
+    cast(dict[str, object], pull_request["head"])["sha"] = "c" * 40
+    with pytest.raises(ValueError, match="head moved"):
         verify_native_auto_merge("KayzenRoot/hive", 42, "b" * 40)
 
 
@@ -529,6 +601,9 @@ def test_g1_pr_body_describes_identity_correction() -> None:
     assert body.startswith("<!-- HIVE-WORK-ORDER: WO-008-G1 -->")
     assert "GITHUB_TOKEN" in body
     assert "gh pr merge --auto" in body
+    assert "python -m pytest" in body
+    assert "Riscos conhecidos" in body
+    assert "docs/project-brain/13-CHECKPOINT.md" in body
     assert "WO-008-G1 READY FOR SOL GITHUB AUDIT" in body
     assert "fundação de reranking" not in body
 
@@ -604,20 +679,22 @@ def test_sticky_summary_has_required_review_fields() -> None:
         "Secret scan",
         "Consolidated artifact",
         "Workflow run URL",
+        "Ruleset unchanged",
         "Auto-merge owner: KayzenRoot (User)",
         "Sol Review State: AWAITING_SOL",
     ):
         assert field in summary
 
 
-def test_wo008_c1_evidence_fails_closed_on_missing_safety_proof() -> None:
+@pytest.mark.parametrize("work_order", ["WO-008", "WO-008-G1"])
+def test_wo008_c1_evidence_fails_closed_on_missing_safety_proof(work_order: str) -> None:
     required = {field: True for field in review_evidence.RERANK_C1_REQUIRED_FIELDS}
     benchmark = {"status": "PASS", "rerank": {"status": "PASS", **required}}
     integration = {"integrity_tests": required}
     security = {"reranking": {"status": "PASS"}}
 
     require_wo008_c1_evidence(
-        "WO-008", benchmark, integration, security, "bounded evidence", "review text"
+        work_order, benchmark, integration, security, "bounded evidence", "review text"
     )
 
     failed_benchmark = {
@@ -626,7 +703,12 @@ def test_wo008_c1_evidence_fails_closed_on_missing_safety_proof() -> None:
     }
     with pytest.raises(ValueError, match="mandatory rerank C1 evidence"):
         require_wo008_c1_evidence(
-            "WO-008", failed_benchmark, integration, security, "bounded evidence", "review text"
+            work_order,
+            failed_benchmark,
+            integration,
+            security,
+            "bounded evidence",
+            "review text",
         )
 
 

--- a/backend/tests/test_review_evidence.py
+++ b/backend/tests/test_review_evidence.py
@@ -11,6 +11,7 @@ from scripts.capture_service_logs import DEFAULT_COMMAND, capture_service_logs, 
 from scripts.review_bundle import deterministic_zip
 from scripts.review_evidence import (
     SCHEMA_PATH,
+    auto_merge_evidence,
     canonical_change_evidence,
     canonical_change_statement,
     dashboard_counts,
@@ -21,6 +22,7 @@ from scripts.review_evidence import (
     require_wo008_c1_evidence,
     summary_markdown,
     validate_manifest,
+    verify_native_auto_merge,
     warnings_evidence,
     write_consolidated_artifact,
 )
@@ -130,13 +132,35 @@ def evidence_fixture() -> dict[str, object]:
                 "delete_branch_on_merge": True,
                 "allow_auto_merge": False,
             },
+            "pull_request": {
+                "number": 42,
+                "state": "open",
+                "is_draft": True,
+                "head_sha": "b" * 40,
+                "base_sha": "a" * 40,
+                "auto_merge_armed": True,
+                "auto_merge_method": "squash",
+                "auto_merge": {
+                    "armed": True,
+                    "method": "squash",
+                    "enabled_by_login": "KayzenRoot",
+                    "enabled_by_type": "User",
+                    "user_owned": True,
+                },
+            },
         },
         "artifact": {
             "name": "hive-review-evidence-WO-006-head",
             "format": "consolidated-directory",
             "bounded": True,
         },
-        "review_state": {"status": "DRAFT", "merge_performed": False},
+        "review_state": {
+            "status": "DRAFT",
+            "merge_performed": False,
+            "auto_merge_owner_login": "KayzenRoot",
+            "auto_merge_owner_type": "User",
+            "auto_merge_user_owned": True,
+        },
         "negative_scope": [
             "No merge or release was performed.",
             canonical_change_statement(canonical_change_evidence(["backend/app/main.py"])),
@@ -242,6 +266,13 @@ def handoff_governance(
             "base_sha": base_sha,
             "auto_merge_armed": auto_merge_armed,
             "auto_merge_method": auto_merge_method,
+            "auto_merge": {
+                "armed": auto_merge_armed,
+                "method": auto_merge_method,
+                "enabled_by_login": "KayzenRoot" if auto_merge_armed else "",
+                "enabled_by_type": "User" if auto_merge_armed else "",
+                "user_owned": auto_merge_armed,
+            },
         },
         "approval_gate": {"independent_approval_count": independent_approval_count},
     }
@@ -266,6 +297,103 @@ def test_hive_final_handoff_requires_armed_squash_and_zero_approvals() -> None:
 def test_hive_final_handoff_rejects_manifest_pr_head_mismatch() -> None:
     with pytest.raises(ValueError, match="does not match PR head"):
         require_hive_final_handoff("WO-007-P", 28, "a" * 40, "c" * 40, handoff_governance())
+
+
+def native_auto_merge_pull_request(auto_merge: object) -> dict[str, object]:
+    return {
+        "state": "open",
+        "draft": False,
+        "head": {"sha": "b" * 40},
+        "auto_merge": auto_merge,
+    }
+
+
+def test_user_owned_squash_auto_merge_is_accepted(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    pull_request = native_auto_merge_pull_request(
+        {
+            "merge_method": "squash",
+            "enabled_by": {"login": "KayzenRoot", "type": "User"},
+        }
+    )
+    monkeypatch.setattr(review_evidence, "_gh_json", lambda _repository, _endpoint: pull_request)
+
+    assert verify_native_auto_merge("KayzenRoot/hive", 42, "b" * 40) == {
+        "armed": True,
+        "method": "squash",
+        "enabled_by_login": "KayzenRoot",
+        "enabled_by_type": "User",
+        "user_owned": True,
+    }
+
+
+@pytest.mark.parametrize(
+    ("auto_merge", "message"),
+    [
+        (
+            {
+                "merge_method": "squash",
+                "enabled_by": {"login": "github-actions[bot]", "type": "Bot"},
+            },
+            "github-actions",
+        ),
+        (
+            {
+                "merge_method": "squash",
+                "enabled_by": {"login": "automation-app", "type": "App"},
+            },
+            "user-owned",
+        ),
+        (
+            {
+                "merge_method": "squash",
+                "enabled_by": {"login": "automation", "type": "Bot"},
+            },
+            "user-owned",
+        ),
+        (None, "not armed"),
+        (
+            {
+                "merge_method": "merge",
+                "enabled_by": {"login": "KayzenRoot", "type": "User"},
+            },
+            "SQUASH",
+        ),
+    ],
+)
+def test_native_auto_merge_verification_fails_closed(
+    monkeypatch: pytest.MonkeyPatch,
+    auto_merge: object,
+    message: str,
+) -> None:
+    pull_request = native_auto_merge_pull_request(auto_merge)
+    monkeypatch.setattr(review_evidence, "_gh_json", lambda _repository, _endpoint: pull_request)
+
+    with pytest.raises(ValueError, match=message):
+        verify_native_auto_merge("KayzenRoot/hive", 42, "b" * 40)
+
+
+def test_auto_merge_identity_is_recorded_without_secret_fields() -> None:
+    evidence = auto_merge_evidence(
+        {
+            "merge_method": "squash",
+            "enabled_by": {
+                "login": "KayzenRoot",
+                "type": "User",
+                "token": "must-not-be-copied",
+            },
+        }
+    )
+
+    assert evidence == {
+        "armed": True,
+        "method": "squash",
+        "enabled_by_login": "KayzenRoot",
+        "enabled_by_type": "User",
+        "user_owned": True,
+    }
+    assert "must-not-be-copied" not in json.dumps(evidence)
 
 
 def test_review_evidence_rejects_merge_claim() -> None:
@@ -384,6 +512,27 @@ def test_pr_body_template_contains_work_order_marker_and_sol_state() -> None:
     assert body.count("## ") == 20
 
 
+def test_g1_pr_body_describes_identity_correction() -> None:
+    body = render_body(
+        work_order="WO-008-G1",
+        pr_number=30,
+        branch="fix/wo008-postmerge-ci-automerge-identity",
+        base_sha="a" * 40,
+        head_sha="b" * 40,
+        artifact_name="hive-review-evidence-WO-008-G1-b",
+        ruleset_before="old",
+        ruleset_after="unchanged",
+        merge_before="old",
+        merge_after="unchanged",
+    )
+
+    assert body.startswith("<!-- HIVE-WORK-ORDER: WO-008-G1 -->")
+    assert "GITHUB_TOKEN" in body
+    assert "gh pr merge --auto" in body
+    assert "WO-008-G1 READY FOR SOL GITHUB AUDIT" in body
+    assert "fundação de reranking" not in body
+
+
 def test_consolidated_artifact_contains_the_required_audit_inputs(tmp_path: Path) -> None:
     manifest = evidence_fixture()
     manifest["large_audit_field"] = "x" * review_evidence.MAX_EVIDENCE_CHARS
@@ -431,6 +580,9 @@ def test_ci_persists_bounded_service_logs_and_uses_supported_action_majors() -> 
         encoding="utf-8"
     )
     assert DEFAULT_COMMAND == ("docker", "compose", "logs", "--no-color", "--tail=200")
+    assert "on:\n  push:\n    branches:\n      - main" in workflow
+    assert "--verify-auto-merge" in workflow
+    assert "gh pr merge" not in workflow
     assert "tmp/integration-logs/service-logs.log" in workflow
     assert "path: |\n            tmp/validation\n            tmp/integration-logs" in workflow
     assert "actions/upload-artifact@v7" in workflow
@@ -452,6 +604,7 @@ def test_sticky_summary_has_required_review_fields() -> None:
         "Secret scan",
         "Consolidated artifact",
         "Workflow run URL",
+        "Auto-merge owner: KayzenRoot (User)",
         "Sol Review State: AWAITING_SOL",
     ):
         assert field in summary

--- a/schemas/review-evidence-v1.schema.json
+++ b/schemas/review-evidence-v1.schema.json
@@ -316,7 +316,8 @@
             "head_sha": { "type": ["string", "null"] },
             "base_sha": { "type": ["string", "null"] },
             "auto_merge_armed": { "type": "boolean" },
-            "auto_merge_method": { "type": ["string", "null"] }
+            "auto_merge_method": { "type": ["string", "null"] },
+            "auto_merge": { "$ref": "#/$defs/auto_merge" }
           }
         },
         "approval_gate": {
@@ -361,7 +362,10 @@
         "merge_performed": { "const": false },
         "sol_review_state": { "type": "string", "enum": ["AWAITING_SOL", "APPROVED", "REJECTED"] },
         "auto_merge_armed": { "type": "boolean" },
-        "auto_merge_method": { "type": ["string", "null"] }
+        "auto_merge_method": { "type": ["string", "null"] },
+        "auto_merge_owner_login": { "type": "string" },
+        "auto_merge_owner_type": { "type": "string" },
+        "auto_merge_user_owned": { "type": "boolean" }
       }
     },
     "negative_scope": {
@@ -378,6 +382,24 @@
       "properties": {
         "status": { "type": "string", "enum": ["PASS", "FAIL", "UNKNOWN"] },
         "evidence_file": { "type": "string", "minLength": 1 }
+      }
+    },
+    "auto_merge": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "armed",
+        "method",
+        "enabled_by_login",
+        "enabled_by_type",
+        "user_owned"
+      ],
+      "properties": {
+        "armed": { "type": "boolean" },
+        "method": { "type": ["string", "null"] },
+        "enabled_by_login": { "type": "string" },
+        "enabled_by_type": { "type": "string" },
+        "user_owned": { "type": "boolean" }
       }
     },
     "bypass_actor": {

--- a/schemas/review-evidence-v1.schema.json
+++ b/schemas/review-evidence-v1.schema.json
@@ -306,6 +306,7 @@
             "allow_auto_merge": { "type": ["boolean", "null"] }
           }
         },
+        "ruleset_unchanged": { "type": "boolean" },
         "pull_request": {
           "type": "object",
           "additionalProperties": false,

--- a/scripts/review_evidence.py
+++ b/scripts/review_evidence.py
@@ -46,6 +46,17 @@ CANONICAL_PATHS = (
     CHECKPOINT_PATH,
     "docs/project-brain/CANONICAL-SHA256SUMS.txt",
 )
+WO008_G1_BASE_SHA = "fcbf0849a54e0283ed523e09ce18ea31a8bd7849"
+WO008_G1_ALLOWED_PATHS = frozenset(
+    {
+        ".github/workflows/ci.yml",
+        "backend/tests/test_review_evidence.py",
+        "schemas/review-evidence-v1.schema.json",
+        "scripts/review_evidence.py",
+        "scripts/review_pr_body.py",
+    }
+)
+PROTECTED_MAIN_RULESET_ID = 21934284
 
 WARNING_RULES = (
     (
@@ -132,6 +143,19 @@ def canonical_change_evidence(paths: list[str]) -> dict[str, object]:
 def canonical_change_statement(evidence: dict[str, object]) -> str:
     payload = json.dumps(evidence, sort_keys=True, separators=(",", ":"))
     return f"Canonical change evidence: {payload}"
+
+
+def require_wo008_g1_scope(work_order: str, base_sha: str, paths: list[str]) -> None:
+    if work_order != "WO-008-G1":
+        return
+    if base_sha != WO008_G1_BASE_SHA:
+        raise ValueError(f"WO-008-G1 requires exact base {WO008_G1_BASE_SHA}, observed {base_sha}")
+    unauthorized = sorted(set(paths) - WO008_G1_ALLOWED_PATHS)
+    if unauthorized:
+        raise ValueError(
+            "WO-008-G1 changed files outside the approved governance scope: "
+            + ", ".join(unauthorized)
+        )
 
 
 def repository_name() -> str:
@@ -603,7 +627,7 @@ def require_wo008_c1_evidence(
     all_evidence: str,
     github_evidence: str,
 ) -> None:
-    if work_order != "WO-008":
+    if not work_order.startswith("WO-008"):
         return
     rerank = cast(dict[str, Any], benchmark.get("rerank", {}))
     integrity = cast(dict[str, Any], integration.get("integrity_tests", {}))
@@ -673,6 +697,21 @@ def auto_merge_evidence(auto_merge: Mapping[str, Any] | None) -> dict[str, objec
             and not is_app
             and normalized_login != "github-actions[bot]"
         ),
+    }
+
+
+def pull_request_auto_merge_evidence(
+    pull_request_governance: Mapping[str, Any],
+) -> Mapping[str, Any]:
+    auto_merge = pull_request_governance.get("auto_merge")
+    if isinstance(auto_merge, Mapping):
+        return auto_merge
+    return {
+        "armed": pull_request_governance.get("auto_merge_armed"),
+        "method": pull_request_governance.get("auto_merge_method"),
+        "enabled_by_login": pull_request_governance.get("auto_merge_owner_login", ""),
+        "enabled_by_type": pull_request_governance.get("auto_merge_owner_type", ""),
+        "user_owned": pull_request_governance.get("auto_merge_user_owned", False),
     }
 
 
@@ -797,6 +836,22 @@ def governance_evidence(repository: str, pr_number: int | None = None) -> dict[s
         if isinstance(ruleset, dict)
         else []
     )
+    ruleset_unchanged = (
+        ruleset.get("id") == PROTECTED_MAIN_RULESET_ID
+        and ruleset.get("name") == "Protect main"
+        and ruleset.get("enforcement") == "active"
+        and sorted(required_contexts) == ["Integration health", "Review Evidence", "Validate"]
+        and thread_resolution is True
+        and sorted(allowed_methods) == ["squash"]
+        and not bypass
+        and has_deletion
+        and has_non_fast_forward
+        and has_pull_request
+        and strict_checks is True
+        and required_approving_review_count == 1
+        and dismiss_stale_reviews_on_push is True
+        and require_last_push_approval is True
+    )
     repo_settings = {
         "allow_squash_merge": repo.get("allow_squash_merge") if isinstance(repo, dict) else None,
         "allow_merge_commit": repo.get("allow_merge_commit") if isinstance(repo, dict) else None,
@@ -888,6 +943,7 @@ def governance_evidence(repository: str, pr_number: int | None = None) -> dict[s
             "dismiss_stale_reviews_on_push": dismiss_stale_reviews_on_push,
             "require_last_push_approval": require_last_push_approval,
         },
+        "ruleset_unchanged": ruleset_unchanged,
         "repository_merge_settings": repo_settings,
         "pull_request": {
             "number": pr_number,
@@ -946,6 +1002,7 @@ def build_manifest(args: argparse.Namespace) -> dict[str, object]:
     if head_sha != actual_head:
         raise ValueError(f"head SHA mismatch: expected {head_sha}, checked out {actual_head}")
     paths = changed_paths(base_sha, head_sha)
+    require_wo008_g1_scope(work_order, base_sha, paths)
     all_validation = validation + "\n" + lint + "\n" + tests_text
     evidence_text = all_evidence_text()
     github_evidence = github_review_text(repository, args.pr_number)
@@ -971,8 +1028,7 @@ def build_manifest(args: argparse.Namespace) -> dict[str, object]:
     canonical_changes = canonical_change_evidence(paths)
     governance = governance_evidence(repository, args.pr_number)
     pr_governance = cast(dict[str, Any], governance.get("pull_request", {}))
-    pr_auto_merge = pr_governance.get("auto_merge")
-    pr_auto_merge = pr_auto_merge if isinstance(pr_auto_merge, Mapping) else {}
+    pr_auto_merge = pull_request_auto_merge_evidence(pr_governance)
     require_hive_final_handoff(work_order, args.pr_number, base_sha, head_sha, governance)
     checks = {
         "validation": "PASS"
@@ -1071,6 +1127,21 @@ def validate_manifest(manifest: dict[str, object]) -> None:
     }
     if set(manifest) != required or manifest["schema_version"] != 1:
         raise ValueError("manifest does not match the required top-level schema")
+    work_order = cast(str, manifest["work_order"])
+    if work_order == "WO-008-G1":
+        base = cast(dict[str, Any], manifest["base"])
+        changed_files = cast(dict[str, Any], manifest["changed_files"])
+        require_wo008_g1_scope(
+            work_order,
+            cast(str, base["sha"]),
+            cast(list[str], changed_files["paths"]),
+        )
+        governance = cast(dict[str, Any], manifest["governance"])
+        if governance.get("ruleset_unchanged") is not True:
+            raise ValueError("WO-008-G1 evidence requires the protected ruleset to be unchanged")
+        review_state = cast(dict[str, Any], manifest["review_state"])
+        if review_state.get("auto_merge_user_owned") is not True:
+            raise ValueError("WO-008-G1 evidence requires user-owned auto-merge")
     for key in ("base", "head"):
         section = cast(dict[str, Any], manifest[key])
         sha = section["sha"]
@@ -1232,6 +1303,7 @@ def summary_markdown(manifest: dict[str, object], workflow_url: str) -> str:
         f"thread resolution `{ruleset['required_review_thread_resolution']}`; "
         f"merge methods `{methods}`; bypass actors `{len(ruleset['bypass_actors'])}`"
     )
+    ruleset_unchanged = governance.get("ruleset_unchanged", False)
     race_summary = (
         f"HEAD `{integrity['head_race_rejected']}`, "
         f"inventory `{integrity['inventory_race_rejected']}`, "
@@ -1298,6 +1370,7 @@ def summary_markdown(manifest: dict[str, object], workflow_url: str) -> str:
 - Known warnings: `{warnings["count"]}` recorded
 {warning_lines}
 - Ruleset: {ruleset_text}
+- Ruleset unchanged: `{ruleset_unchanged}`
 - Repository merge settings: {merge_settings}
 - Auto-merge armed: {auto_merge_text}
 - Auto-merge owner: {auto_merge_owner_text}; user-owned: `{auto_merge_user_owned}`
@@ -1318,6 +1391,12 @@ def require_hive_final_handoff(
 ) -> None:
     if not pr_number or not work_order.startswith("WO-"):
         return
+    if work_order == "WO-008-G1" and base_sha != WO008_G1_BASE_SHA:
+        raise ValueError(
+            f"WO-008-G1 final handoff requires exact base {WO008_G1_BASE_SHA}, observed {base_sha}"
+        )
+    if work_order == "WO-008-G1" and governance.get("ruleset_unchanged") is not True:
+        raise ValueError("WO-008-G1 final handoff requires the protected ruleset to be unchanged")
     pr_governance = cast(dict[str, Any], governance.get("pull_request", {}))
     if pr_governance.get("head_sha") != head_sha:
         observed_head = pr_governance.get("head_sha")
@@ -1329,15 +1408,7 @@ def require_hive_final_handoff(
         raise ValueError("HIVE final-handoff evidence requires an open pull request")
     if pr_governance.get("is_draft") is not False:
         raise ValueError("HIVE final-handoff evidence requires a Ready pull request")
-    auto_merge_state = pr_governance.get("auto_merge")
-    if not isinstance(auto_merge_state, Mapping):
-        auto_merge_state = {
-            "armed": pr_governance.get("auto_merge_armed"),
-            "method": pr_governance.get("auto_merge_method"),
-            "enabled_by_login": pr_governance.get("auto_merge_owner_login", ""),
-            "enabled_by_type": pr_governance.get("auto_merge_owner_type", ""),
-            "user_owned": pr_governance.get("auto_merge_user_owned", False),
-        }
+    auto_merge_state = pull_request_auto_merge_evidence(pr_governance)
     if auto_merge_state.get("armed") is not True:
         raise ValueError("HIVE final-handoff evidence requires native auto-merge to be armed")
     if str(auto_merge_state.get("method", "")).casefold() != "squash":

--- a/scripts/review_evidence.py
+++ b/scripts/review_evidence.py
@@ -640,6 +640,78 @@ def _gh_json(repository: str, endpoint: str) -> dict[str, Any] | list[Any] | Non
     return value if isinstance(value, dict | list) else None
 
 
+def auto_merge_evidence(auto_merge: Mapping[str, Any] | None) -> dict[str, object]:
+    owner = auto_merge.get("enabled_by") if isinstance(auto_merge, Mapping) else None
+    owner = owner if isinstance(owner, Mapping) else {}
+    login_value = owner.get("login")
+    type_value = owner.get("type")
+    if not isinstance(type_value, str):
+        type_value = owner.get("__typename")
+    login = login_value.strip() if isinstance(login_value, str) else ""
+    owner_type = type_value.strip() if isinstance(type_value, str) else ""
+    normalized_login = login.casefold()
+    normalized_type = owner_type.casefold()
+    is_bot = (
+        owner.get("is_bot") is True
+        or normalized_type == "bot"
+        or normalized_login.endswith("[bot]")
+    )
+    is_app = normalized_type in {"app", "application"} or normalized_login.startswith("app/")
+    return {
+        "armed": auto_merge is not None,
+        "method": (
+            auto_merge.get("merge_method")
+            if isinstance(auto_merge, Mapping) and isinstance(auto_merge.get("merge_method"), str)
+            else None
+        ),
+        "enabled_by_login": login,
+        "enabled_by_type": owner_type,
+        "user_owned": bool(
+            login
+            and normalized_type == "user"
+            and not is_bot
+            and not is_app
+            and normalized_login != "github-actions[bot]"
+        ),
+    }
+
+
+def verify_native_auto_merge(
+    repository: str,
+    pr_number: int,
+    expected_head_sha: str | None = None,
+) -> dict[str, object]:
+    pull_request = _gh_json(repository, f"pulls/{pr_number}")
+    if not isinstance(pull_request, dict):
+        raise ValueError(f"unable to read pull request #{pr_number} for auto-merge verification")
+    if pull_request.get("state") != "open":
+        raise ValueError("auto-merge verification requires an open pull request")
+    if pull_request.get("draft") is not False:
+        raise ValueError("auto-merge verification requires a Ready pull request")
+    head = pull_request.get("head")
+    observed_head_sha = head.get("sha") if isinstance(head, Mapping) else None
+    if expected_head_sha and observed_head_sha != expected_head_sha:
+        raise ValueError(
+            f"pull request head moved: expected {expected_head_sha}, observed {observed_head_sha}"
+        )
+    raw_auto_merge = pull_request.get("auto_merge")
+    auto_merge = raw_auto_merge if isinstance(raw_auto_merge, Mapping) else None
+    evidence = auto_merge_evidence(auto_merge)
+    if evidence["armed"] is not True:
+        raise ValueError("native auto-merge is not armed")
+    if str(evidence["method"]).casefold() != "squash":
+        raise ValueError("native auto-merge must use SQUASH")
+    if not evidence["enabled_by_login"]:
+        raise ValueError("auto-merge owner login is missing")
+    if evidence["user_owned"] is not True:
+        raise ValueError(
+            "native auto-merge must be user-owned; enabled-by identity "
+            f"{evidence['enabled_by_login']} ({evidence['enabled_by_type'] or 'unknown'}) "
+            "is not a GitHub User"
+        )
+    return evidence
+
+
 def github_review_text(repository: str, pr_number: int | None) -> str:
     if not pr_number:
         return ""
@@ -795,6 +867,7 @@ def governance_evidence(repository: str, pr_number: int | None = None) -> dict[s
         if isinstance(pr, dict) and isinstance(pr.get("auto_merge"), dict)
         else None
     )
+    auto_merge_state = auto_merge_evidence(auto_merge)
     return {
         "status": "PASS" if available else "UNKNOWN",
         "ruleset": {
@@ -832,6 +905,7 @@ def governance_evidence(repository: str, pr_number: int | None = None) -> dict[s
             ),
             "auto_merge_armed": auto_merge is not None,
             "auto_merge_method": auto_merge.get("merge_method") if auto_merge else None,
+            "auto_merge": auto_merge_state,
         },
         "approval_gate": {
             "required_approving_review_count": required_approving_review_count,
@@ -897,6 +971,8 @@ def build_manifest(args: argparse.Namespace) -> dict[str, object]:
     canonical_changes = canonical_change_evidence(paths)
     governance = governance_evidence(repository, args.pr_number)
     pr_governance = cast(dict[str, Any], governance.get("pull_request", {}))
+    pr_auto_merge = pr_governance.get("auto_merge")
+    pr_auto_merge = pr_auto_merge if isinstance(pr_auto_merge, Mapping) else {}
     require_hive_final_handoff(work_order, args.pr_number, base_sha, head_sha, governance)
     checks = {
         "validation": "PASS"
@@ -962,6 +1038,9 @@ def build_manifest(args: argparse.Namespace) -> dict[str, object]:
             "sol_review_state": "AWAITING_SOL",
             "auto_merge_armed": bool(pr_governance.get("auto_merge_armed", False)),
             "auto_merge_method": pr_governance.get("auto_merge_method"),
+            "auto_merge_owner_login": pr_auto_merge.get("enabled_by_login", ""),
+            "auto_merge_owner_type": pr_auto_merge.get("enabled_by_type", ""),
+            "auto_merge_user_owned": bool(pr_auto_merge.get("user_owned", False)),
         },
         "negative_scope": [
             "No merge or release was performed.",
@@ -1168,6 +1247,11 @@ def summary_markdown(manifest: dict[str, object], workflow_url: str) -> str:
         f"`{review_state.get('auto_merge_armed', False)}` / "
         f"`{review_state.get('auto_merge_method') or 'none'}`"
     )
+    auto_merge_owner_text = (
+        f"{review_state.get('auto_merge_owner_login') or 'none'} "
+        f"({review_state.get('auto_merge_owner_type') or 'unknown'})"
+    )
+    auto_merge_user_owned = review_state.get("auto_merge_user_owned", False)
     approval_text = (
         f"`{ruleset.get('required_approving_review_count')}`; "
         f"independent approvals observed: "
@@ -1216,6 +1300,7 @@ def summary_markdown(manifest: dict[str, object], workflow_url: str) -> str:
 - Ruleset: {ruleset_text}
 - Repository merge settings: {merge_settings}
 - Auto-merge armed: {auto_merge_text}
+- Auto-merge owner: {auto_merge_owner_text}; user-owned: `{auto_merge_user_owned}`
 - Required independent approvals: {approval_text}
 - Consolidated artifact: `{artifact["name"]}`
 - Workflow run URL: {workflow_url}
@@ -1244,10 +1329,23 @@ def require_hive_final_handoff(
         raise ValueError("HIVE final-handoff evidence requires an open pull request")
     if pr_governance.get("is_draft") is not False:
         raise ValueError("HIVE final-handoff evidence requires a Ready pull request")
-    if pr_governance.get("auto_merge_armed") is not True:
+    auto_merge_state = pr_governance.get("auto_merge")
+    if not isinstance(auto_merge_state, Mapping):
+        auto_merge_state = {
+            "armed": pr_governance.get("auto_merge_armed"),
+            "method": pr_governance.get("auto_merge_method"),
+            "enabled_by_login": pr_governance.get("auto_merge_owner_login", ""),
+            "enabled_by_type": pr_governance.get("auto_merge_owner_type", ""),
+            "user_owned": pr_governance.get("auto_merge_user_owned", False),
+        }
+    if auto_merge_state.get("armed") is not True:
         raise ValueError("HIVE final-handoff evidence requires native auto-merge to be armed")
-    if str(pr_governance.get("auto_merge_method", "")).casefold() != "squash":
+    if str(auto_merge_state.get("method", "")).casefold() != "squash":
         raise ValueError("HIVE final-handoff evidence requires SQUASH auto-merge")
+    if not auto_merge_state.get("enabled_by_login") or not auto_merge_state.get("enabled_by_type"):
+        raise ValueError("HIVE final-handoff evidence requires auto-merge owner identity")
+    if auto_merge_state.get("user_owned") is not True:
+        raise ValueError("HIVE final-handoff evidence requires user-owned auto-merge")
     approval_gate = cast(dict[str, Any], governance.get("approval_gate", {}))
     if approval_gate.get("independent_approval_count") != 0:
         raise ValueError(
@@ -1315,6 +1413,8 @@ def main() -> int:
     parser.add_argument("--repository")
     parser.add_argument("--pr-number", type=int)
     parser.add_argument("--resolve-work-order", action="store_true")
+    parser.add_argument("--verify-auto-merge", action="store_true")
+    parser.add_argument("--expected-head-sha", default="")
     parser.add_argument("--draft", action="store_true")
     parser.add_argument("--ready", action="store_true")
     parser.add_argument("--draft-env", default="")
@@ -1331,6 +1431,21 @@ def main() -> int:
     )
     parser.add_argument("--output-dir", type=Path, default=DEFAULT_OUTPUT)
     args = parser.parse_args()
+    if args.verify_auto_merge:
+        if args.pr_number is None:
+            parser.error("--verify-auto-merge requires --pr-number")
+        if not HEX_SHA.fullmatch(args.expected_head_sha):
+            parser.error("--verify-auto-merge requires a 40-character expected head SHA")
+        try:
+            evidence = verify_native_auto_merge(
+                args.repository or repository_name(),
+                args.pr_number,
+                args.expected_head_sha,
+            )
+        except ValueError as error:
+            parser.error(str(error))
+        print(json.dumps(evidence, sort_keys=True))
+        return 0
     if args.resolve_work_order:
         if args.pr_number is None:
             parser.error("--resolve-work-order requires --pr-number")

--- a/scripts/review_evidence.py
+++ b/scripts/review_evidence.py
@@ -627,7 +627,7 @@ def require_wo008_c1_evidence(
     all_evidence: str,
     github_evidence: str,
 ) -> None:
-    if not work_order.startswith("WO-008"):
+    if work_order != "WO-008" and not work_order.startswith("WO-008-"):
         return
     rerank = cast(dict[str, Any], benchmark.get("rerank", {}))
     integrity = cast(dict[str, Any], integration.get("integrity_tests", {}))
@@ -723,6 +723,8 @@ def verify_native_auto_merge(
     pull_request = _gh_json(repository, f"pulls/{pr_number}")
     if not isinstance(pull_request, dict):
         raise ValueError(f"unable to read pull request #{pr_number} for auto-merge verification")
+    if expected_head_sha is not None and not HEX_SHA.fullmatch(expected_head_sha):
+        raise ValueError("auto-merge verification requires a 40-character expected head SHA")
     if pull_request.get("state") != "open":
         raise ValueError("auto-merge verification requires an open pull request")
     if pull_request.get("draft") is not False:
@@ -1142,6 +1144,13 @@ def validate_manifest(manifest: dict[str, object]) -> None:
         review_state = cast(dict[str, Any], manifest["review_state"])
         if review_state.get("auto_merge_user_owned") is not True:
             raise ValueError("WO-008-G1 evidence requires user-owned auto-merge")
+        if not review_state.get("auto_merge_owner_login") or not review_state.get(
+            "auto_merge_owner_type"
+        ):
+            raise ValueError("WO-008-G1 evidence requires auto-merge owner identity")
+        governance_pr = cast(dict[str, Any], governance.get("pull_request", {}))
+        if not isinstance(governance_pr.get("auto_merge"), Mapping):
+            raise ValueError("WO-008-G1 evidence requires structured auto-merge evidence")
     for key in ("base", "head"):
         section = cast(dict[str, Any], manifest[key])
         sha = section["sha"]

--- a/scripts/review_pr_body.py
+++ b/scripts/review_pr_body.py
@@ -218,6 +218,15 @@ SQUASH e owner User. Ele não executa `gh pr merge --auto`.
 Há fixtures para owner User aceito, `github-actions[bot]`, Bot, App, ausência
 de auto-merge e método incorreto rejeitados, além de cobertura do trigger push
 para `main` e da ausência da mutação no workflow.
+As gates de evidência C1 do WO-008 permanecem obrigatórias nesta correção.
+
+Comandos de validação: `python scripts/verify_canonical_sources.py`,
+`python scripts/check_secrets.py`, `python scripts/generate_maps.py --check`,
+`python -m ruff format --check backend scripts migrations`,
+`python -m ruff check backend scripts migrations`, `python -m mypy`,
+`python -m pytest`, `cd dashboard && npm ci && npm run lint && npm run typecheck
+&& npm run test:run && npm run build && npm audit`, e `docker compose config
+--quiet`.
 
 ## 7. CI da PR e artefato
 
@@ -225,18 +234,31 @@ Validate, Integration health e Review Evidence devem passar no head exato.
 O consolidado é `{artifact_name}` e o sticky comment deve expor o owner sem
 segredos.
 
-## 8. Governança
+## 8. Riscos conhecidos e fontes canônicas
+
+O fluxo depende de o executor armar o auto-merge como User; ausência, Bot ou
+App bloqueia o handoff. Em hosts Windows, o init de PostgreSQL em bind mount
+pode exceder o healthcheck padrão, sem alterar a configuração de produção.
+Fontes: [checkpoint](../blob/main/docs/project-brain/13-CHECKPOINT.md),
+[decisões](../blob/main/docs/project-brain/16-DECISIONS-LEDGER.md),
+[escopo](../blob/main/docs/project-brain/03-SCOPE.md),
+[Definition of Done](../blob/main/docs/project-brain/15-DEFINITION-OF-DONE.md),
+[arquitetura](../blob/main/docs/project-brain/04-ARCHITECTURE.md) e
+[requisitos](../blob/main/docs/project-brain/02-REQUIREMENTS.md).
+
+## 9. Governança
 
 Antes: {ruleset_before}; merge: {merge_before}. Depois: {ruleset_after}; merge:
 {merge_after}. A proteção permanece ativa, com os três checks reais,
-SQUASH-only, uma aprovação independente exigida e zero bypass.
+SQUASH-only, uma aprovação independente exigida e zero bypass. Ruleset unchanged:
+`true`, verificado contra o Ruleset 21934284.
 
-## 9. Escopo negativo
+## 10. Escopo negativo
 
 Não foi feita alteração de produto, migration, promoção do checkpoint, merge
 manual, bypass, aprovação automática de Sol ou início de WO-009.
 
-## 10. Estado de Sol
+## 11. Estado de Sol
 
 A PR permanece aberta, Ready e não mesclada. Aprovações independentes
 observadas: zero. Sol Review State: AWAITING_SOL.

--- a/scripts/review_pr_body.py
+++ b/scripts/review_pr_body.py
@@ -166,6 +166,85 @@ WO-008-C1 READY FOR SOL GITHUB AUDIT
 """
 
 
+def _render_wo008_g1_body(
+    *,
+    work_order: str,
+    pr_number: int,
+    branch: str,
+    base_sha: str,
+    head_sha: str,
+    artifact_name: str,
+    ruleset_before: str,
+    ruleset_after: str,
+    merge_before: str,
+    merge_after: str,
+) -> str:
+    return f"""<!-- HIVE-WORK-ORDER: {work_order} -->
+
+# Revisão do executor — {work_order}
+
+## 1. Resumo executivo
+
+Esta correção preserva o CI pós-merge em `main`: o workflow não arma mais
+auto-merge com `GITHUB_TOKEN`. O executor deve armar o auto-merge nativo
+SQUASH a partir de uma identidade GitHub User; o Review Evidence apenas
+verifica e registra essa identidade.
+
+## 2. Base, branch e head
+
+- PR: #{pr_number}, aberta como Ready for review.
+- Branch: `{branch}`.
+- Base exata auditada: `{base_sha}`.
+- Head exato desta revisão: `{head_sha}`.
+
+## 3. Arquivos alterados
+
+As alterações ficam restritas ao workflow CI, ao gerador/verificador de Review
+Evidence, ao schema e aos testes determinísticos de governança.
+
+## 4. Ownership do auto-merge
+
+O auto-merge deve estar armado externamente pelo executor autenticado como uma
+identidade GitHub User. O manifesto e o sticky comment registram o login e o
+tipo observados, sem expor credenciais; identidades Bot/App falham fechado.
+
+## 5. Mudança no workflow
+
+O job Review Evidence verifica PR Ready, head exato, auto-merge armado, método
+SQUASH e owner User. Ele não executa `gh pr merge --auto`.
+
+## 6. Testes
+
+Há fixtures para owner User aceito, `github-actions[bot]`, Bot, App, ausência
+de auto-merge e método incorreto rejeitados, além de cobertura do trigger push
+para `main` e da ausência da mutação no workflow.
+
+## 7. CI da PR e artefato
+
+Validate, Integration health e Review Evidence devem passar no head exato.
+O consolidado é `{artifact_name}` e o sticky comment deve expor o owner sem
+segredos.
+
+## 8. Governança
+
+Antes: {ruleset_before}; merge: {merge_before}. Depois: {ruleset_after}; merge:
+{merge_after}. A proteção permanece ativa, com os três checks reais,
+SQUASH-only, uma aprovação independente exigida e zero bypass.
+
+## 9. Escopo negativo
+
+Não foi feita alteração de produto, migration, promoção do checkpoint, merge
+manual, bypass, aprovação automática de Sol ou início de WO-009.
+
+## 10. Estado de Sol
+
+A PR permanece aberta, Ready e não mesclada. Aprovações independentes
+observadas: zero. Sol Review State: AWAITING_SOL.
+
+WO-008-G1 READY FOR SOL GITHUB AUDIT
+"""
+
+
 def render_body(
     *,
     work_order: str,
@@ -181,6 +260,19 @@ def render_body(
 ) -> str:
     if work_order == "WO-008":
         return _render_wo008_body(
+            work_order=work_order,
+            pr_number=pr_number,
+            branch=branch,
+            base_sha=base_sha,
+            head_sha=head_sha,
+            artifact_name=artifact_name,
+            ruleset_before=ruleset_before,
+            ruleset_after=ruleset_after,
+            merge_before=merge_before,
+            merge_after=merge_after,
+        )
+    if work_order == "WO-008-G1":
+        return _render_wo008_g1_body(
             work_order=work_order,
             pr_number=pr_number,
             branch=branch,


### PR DESCRIPTION
<!-- HIVE-WORK-ORDER: WO-008-G1 -->

# Revisão do executor — WO-008-G1

## 1. Resumo executivo

Esta correção preserva o CI pós-merge em `main`: o workflow não arma mais
auto-merge com `GITHUB_TOKEN`. O executor deve armar o auto-merge nativo
SQUASH a partir de uma identidade GitHub User; o Review Evidence apenas
verifica e registra essa identidade.

## 2. Base, branch e head

- PR: #30, aberta como Ready for review.
- Branch: `fix/wo008-postmerge-ci-automerge-identity`.
- Base exata auditada: `fcbf0849a54e0283ed523e09ce18ea31a8bd7849`.
- Head exato desta revisão: `f8165e1ea9544841b7e67c26d4beecf0e986624f`.

## 3. Arquivos alterados

As alterações ficam restritas ao workflow CI, ao gerador/verificador de Review
Evidence, ao schema e aos testes determinísticos de governança.

## 4. Ownership do auto-merge

O auto-merge deve estar armado externamente pelo executor autenticado como uma
identidade GitHub User. O manifesto e o sticky comment registram o login e o
tipo observados, sem expor credenciais; identidades Bot/App falham fechado.

## 5. Mudança no workflow

O job Review Evidence verifica PR Ready, head exato, auto-merge armado, método
SQUASH e owner User. Ele não executa `gh pr merge --auto`.

## 6. Testes

Há fixtures para owner User aceito, `github-actions[bot]`, Bot, App, ausência
de auto-merge e método incorreto rejeitados, além de cobertura do trigger push
para `main` e da ausência da mutação no workflow.
As gates de evidência C1 do WO-008 permanecem obrigatórias nesta correção.

Comandos de validação: `python scripts/verify_canonical_sources.py`,
`python scripts/check_secrets.py`, `python scripts/generate_maps.py --check`,
`python -m ruff format --check backend scripts migrations`,
`python -m ruff check backend scripts migrations`, `python -m mypy`,
`python -m pytest`, `cd dashboard && npm ci && npm run lint && npm run typecheck
&& npm run test:run && npm run build && npm audit`, e `docker compose config
--quiet`.

## 7. CI da PR e artefato

Validate, Integration health e Review Evidence devem passar no head exato.
O consolidado é `hive-review-evidence-WO-008-G1-f8165e1ea9544841b7e67c26d4beecf0e986624f` e o sticky comment deve expor o owner sem
segredos.

## 8. Riscos conhecidos e fontes canônicas

O fluxo depende de o executor armar o auto-merge como User; ausência, Bot ou
App bloqueia o handoff. Em hosts Windows, o init de PostgreSQL em bind mount
pode exceder o healthcheck padrão, sem alterar a configuração de produção.
Fontes: [checkpoint](../blob/main/docs/project-brain/13-CHECKPOINT.md),
[decisões](../blob/main/docs/project-brain/16-DECISIONS-LEDGER.md),
[escopo](../blob/main/docs/project-brain/03-SCOPE.md),
[Definition of Done](../blob/main/docs/project-brain/15-DEFINITION-OF-DONE.md),
[arquitetura](../blob/main/docs/project-brain/04-ARCHITECTURE.md) e
[requisitos](../blob/main/docs/project-brain/02-REQUIREMENTS.md).

## 9. Governança

Antes: Protect main / 21934284 active; checks Validate, Integration health, Review Evidence; approvals 1; squash-only; bypass 0; merge: auto-merge=true; squash=true; merge-commit=true; rebase=false. Depois: Protect main / 21934284 active; checks Validate, Integration health, Review Evidence; approvals 1; squash-only; bypass 0; merge:
auto-merge=true; squash=true; merge-commit=true; rebase=false. A proteção permanece ativa, com os três checks reais,
SQUASH-only, uma aprovação independente exigida e zero bypass. Ruleset unchanged:
`true`, verificado contra o Ruleset 21934284.

## 10. Escopo negativo

Não foi feita alteração de produto, migration, promoção do checkpoint, merge
manual, bypass, aprovação automática de Sol ou início de WO-009.

## 11. Estado de Sol

A PR permanece aberta, Ready e não mesclada. Aprovações independentes
observadas: zero. Sol Review State: AWAITING_SOL.

WO-008-G1 READY FOR SOL GITHUB AUDIT
